### PR TITLE
transcode to UTF-8 without BOM

### DIFF
--- a/DeitiesOfFaerun/DeitiesofFaerun.ini
+++ b/DeitiesOfFaerun/DeitiesofFaerun.ini
@@ -8,7 +8,7 @@
 [Metadata]
 
 # Full name of the mod, without version number
-Name = Deities of Faerûn
+Name = Deities of FaerÃ»n
 
 # Author name or nick, don't use email address
 Author = Raduziel


### PR DESCRIPTION
If you want to use unicode strings like 'û', file must be encoded using o UTF-8 without BOM, not ANSI